### PR TITLE
jmxterm jvms command fixed for Mac OS X 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>

--- a/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
@@ -27,7 +27,7 @@ public class JConsoleClassLoaderFactory
     {
         File javaHome = new File( SystemUtils.JAVA_HOME ).getAbsoluteFile().getParentFile();
         final File toolsJar, jconsoleJar;
-        if ( SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX )
+        if (isBeforeJava7() && isMacOs())
         {
             toolsJar = new File( javaHome, "Classes/classes.jar" );
             jconsoleJar = new File( javaHome, "Classes/jconsole.jar" );
@@ -63,4 +63,13 @@ public class JConsoleClassLoaderFactory
             }
         } );
     }
+
+    private static boolean isBeforeJava7() {
+        return SystemUtils.IS_JAVA_1_5 || SystemUtils.IS_JAVA_1_6;
+    }
+
+    private static boolean isMacOs() {
+        return SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX;
+    }
+
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactoryTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactoryTest.java
@@ -30,7 +30,7 @@ public class JConsoleClassLoaderFactoryTest
         {
             clazz = cl.loadClass( "sun.jvmstat.monitor.MonitoredVm" );
         }
-        else if ( SystemUtils.IS_JAVA_1_6 )
+        else if ( SystemUtils.IS_JAVA_1_6 || SystemUtils.IS_JAVA_1_7 )
         {
             clazz = cl.loadClass( "sun.tools.jconsole.LocalVirtualMachine" );
         }


### PR DESCRIPTION
- For modern JDK 7x there is no need to distinguish Mac OS X behavior from other operating systems
- For older JDKs previous approach should work
  Tested on JDK7u4, JDK1.6.0_29, Mac OS X Lion.
