### PR TITLE
Fix argument processor exception from SetCommand

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
@@ -16,6 +16,7 @@ import org.apache.commons.lang.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.Option;
+import org.cyclopsgroup.jcli.annotation.MultiValue;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;
@@ -127,6 +128,7 @@ public class SetCommand
      * @param arguments Argument list. The first argument is attribute name
      */
     @Argument( description = "name, value, value2..." )
+    @MultiValue
     public final void setArguments( List<String> arguments )
     {
         Validate.notNull( arguments, "Arguments can't be NULL" );


### PR DESCRIPTION
Attempting to do anything involving SetCommand fails for me with e.g.:

```
java.lang.RuntimeException: Can't create argument processor for type class org.cyclopsgroup.jmxterm.cmd.SetCommand with parser org.cyclopsgroup.jcli.GnuParser@5143a680
    at org.cyclopsgroup.jcli.impl.DefaultArgumentProcessorFactory.newProcessor(DefaultArgumentProcessorFactory.java:28)
    at org.cyclopsgroup.jcli.ArgumentProcessor.newInstance(ArgumentProcessor.java:41)
    at org.cyclopsgroup.jcli.ArgumentProcessor.newInstance(ArgumentProcessor.java:28)
    at org.cyclopsgroup.jmxterm.cc.HelpCommand.execute(HelpCommand.java:45)
...
Caused by: java.lang.IllegalArgumentException: Can't find constructor with string for type interface java.util.List
    at org.cyclopsgroup.caff.conversion.SimpleReflectiveConverter.<init>(SimpleReflectiveConverter.java:39)
    at org.cyclopsgroup.caff.conversion.SimpleConverter.<init>(SimpleConverter.java:84)
    at org.cyclopsgroup.caff.conversion.AnnotatedConverter$Builder.toConverter(AnnotatedConverter.java:25)
    at org.cyclopsgroup.caff.conversion.AnnotatedConverter$Builder.access$200(AnnotatedConverter.java:16)
    at org.cyclopsgroup.caff.conversion.AnnotatedConverter.<init>(AnnotatedConverter.java:108)
    at org.cyclopsgroup.jcli.impl.ParsingContextBuilder.createReference(ParsingContextBuilder.java:41)
    at org.cyclopsgroup.jcli.impl.ParsingContextBuilder.build(ParsingContextBuilder.java:115)
    at org.cyclopsgroup.jcli.impl.DefaultArgumentProcessor.<init>(DefaultArgumentProcessor.java:24)
    at org.cyclopsgroup.jcli.impl.DefaultArgumentProcessorFactory.newProcessor(DefaultArgumentProcessorFactory.java:24)
    ... 22 more
Caused by: java.lang.NoSuchMethodException: java.util.List.<init>(java.lang.String)
    at java.lang.Class.getConstructor0(Class.java:2800)
    at java.lang.Class.getConstructor(Class.java:1708)
    at org.cyclopsgroup.caff.conversion.SimpleReflectiveConverter.<init>(SimpleReflectiveConverter.java:30)
    ... 30 more
```

Annotating with @MultiValue appears to fix it.
