### PR TITLE
added some exception handling to avoid marshalling and serialization exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>org.cyclopsgroup</groupId>
         <artifactId>cyclopsgroup-java-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+<!--        <version>1.0.0-SNAPSHOT</version> -->
+<version>0.5</version>
     </parent>
     <artifactId>jmxterm</artifactId>
     <name>JMXTerm</name>

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -82,7 +82,12 @@ public class GetCommand
             MBeanAttributeInfo i = entry.getValue();
             if ( i.isReadable() )
             {
-                Object result = con.getAttribute( name, attributeName );
+                Object result;
+                try {
+                    result = con.getAttribute( name, attributeName );
+                } catch (Exception e) {
+                    result = "Exception: " + e.getClass().getName() + " for "+ attributeName;
+                }
                 if ( simpleFormat )
                 {
                     format.printValue( session.output, result );

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -85,8 +85,14 @@ public class GetCommand
                 Object result;
                 try {
                     result = con.getAttribute( name, attributeName );
+                } catch (javax.management.ReflectionException e) {
+                    result = "Exception:" + e.getClass().getName();
+                } catch (java.io.IOException e) {
+                    result = "Exception:" + e.getClass().getName();
+                } catch (java.lang.NoClassDefFoundError e) {
+                    result = "Exception:" + e.getClass().getName();
                 } catch (Exception e) {
-                    result = "Exception: " + e.getClass().getName() + " for "+ attributeName;
+                    result = "Exception:" + e.getClass().getName();
                 }
                 if ( simpleFormat )
                 {

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
@@ -9,6 +9,8 @@ import javax.management.openmbean.CompositeData;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 
+import java.io.Serializable;
+
 /**
  * A utility to print out object values in particular format.
  * 
@@ -157,7 +159,14 @@ public class ValueOutputFormat
         }
         else
         {
-            output.print( value.toString() );
+            String out;
+            try {
+                out = value.toString();
+            }
+            catch (Exception e) {
+                out = "NOT-SERIALIZABLE class "+value.getClass().getName();
+            }
+            output.print( out );
         }
     }
 }


### PR DESCRIPTION
This patch modifies jmxterm so that any marshalling or Serialization exceptions will not abort:
 ```get *```
But instead will create a line like this:
```
globalProcessor = Exception: java.rmi.UnmarshalException for globalProcessor;
```
