### PR TITLE
Fixes for building & RPM tweaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.cyclopsgroup</groupId>
         <artifactId>cyclopsgroup-java-parent</artifactId>
-        <version>0.5</version>
+        <version>0.6</version>
     </parent>
     <artifactId>jmxterm</artifactId>
     <name>JMXTerm</name>

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,13 @@
                     <distribution>CyclopsGroup.org</distribution>
                     <group>Development/Languages/Java</group>
                     <packager>Jiaqi Guo</packager>
+                    <defaultUsername>root</defaultUsername>
+                    <defaultGroupname>root</defaultGroupname>
+                    <defaultDirmode>555</defaultDirmode>
+                    <defaultFilemode>444</defaultFilemode>
                     <mappings>
                         <mapping>
                             <directory>/usr/share/jmxterm</directory>
-                            <filemode>644</filemode>
                             <sources>
                                 <source>
                                     <location>target/jmxterm-${project.version}-uber.jar</location>


### PR DESCRIPTION
So here's the changes we have made to make this build an RPM successfully.

We modified the parent pom version (see #17) and tweaked the directory ownership and permissions to get it to work.  With the original directory/file permissions the /usr/share/jmxterm was _without_ an execute bit set so simply doing a 'ls' of it caused weirdness:

    psmith@app2.qa5.acx:/home/psmith [UNKNOWN]
    $ ll /usr/share/jmxterm/
    ls: cannot access /usr/share/jmxterm/jmxterm-uber.jar: Permission denied
    total 0
    -????????? ? ? ? ?            ? jmxterm-uber.jar

With these changes the directory can be inspected and the JAR doesn't need execute.