### PR TITLE
Updated pom.xml (and code) to use Apache Commons Lang 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
             <version>3.2</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
@@ -57,10 +57,18 @@
             <artifactId>log4j</artifactId>
             <version>1.2.12</version>
         </dependency>
+        <!--
         <dependency>
             <groupId>org.cyclopsgroup</groupId>
             <artifactId>jcli</artifactId>
             <version>1.0.0-beta-2</version>
+        </dependency>
+        -->
+        <!-- point to my local maven repository -->
+        <dependency>
+            <groupId>org.cyclopsgroup</groupId>
+            <artifactId>jcli</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.cyclopsgroup</groupId>

--- a/src/main/config/classworlds.conf
+++ b/src/main/config/classworlds.conf
@@ -3,7 +3,7 @@ main is org.cyclopsgroup.jmxterm.boot.CliMain from app
   load ${classworlds.lib}/jmxterm.jar
   load ${classworlds.lib}/commons-beanutils.jar
   load ${classworlds.lib}/commons-collections.jar
-  load ${classworlds.lib}/commons-lang.jar
+  load ${classworlds.lib}/commons-lang3.jar
   load ${classworlds.lib}/commons-logging.jar
   load ${classworlds.lib}/commons-io.jar
   load ${classworlds.lib}/caff.jar

--- a/src/main/java/org/cyclopsgroup/jmxterm/Command.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Command.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import javax.management.JMException;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cyclopsgroup.jcli.AutoCompletable;

--- a/src/main/java/org/cyclopsgroup/jmxterm/Session.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/Session.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.io.CommandInput;
 import org.cyclopsgroup.jmxterm.io.CommandOutput;
 import org.cyclopsgroup.jmxterm.io.UnimplementedCommandInput;

--- a/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/SyntaxUtils.java
@@ -8,9 +8,9 @@ import javax.management.remote.JMXServiceURL;
 
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.lang.ClassUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.cyclopsgroup.jmxterm.utils.ValueFormat;
 
 /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import javax.management.remote.JMXConnector;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cyclopsgroup.jcli.ArgumentProcessor;
 import org.cyclopsgroup.jcli.GnuParser;
 import org.cyclopsgroup.jmxterm.SyntaxUtils;

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -2,7 +2,7 @@ package org.cyclopsgroup.jmxterm.boot;
 
 import java.io.File;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.Option;
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
@@ -12,9 +12,9 @@ import java.util.concurrent.locks.ReentrantLock;
 import javax.management.JMException;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.caff.token.EscapingValueTokenizer;
 import org.cyclopsgroup.caff.token.TokenEvent;
 import org.cyclopsgroup.caff.token.TokenEventHandler;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConnectionImpl.java
@@ -6,7 +6,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.Connection;
 
 /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/ConsoleCompletor.java
@@ -5,8 +5,8 @@ import java.util.Collections;
 import java.util.List;
 
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cyclopsgroup.jcli.jline.CliCompletor;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/HelpCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/HelpCommand.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.ArgumentProcessor;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
@@ -1,11 +1,13 @@
 package org.cyclopsgroup.jmxterm.cc;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.jdk5.Jdk5JavaProcessManager;
 import org.cyclopsgroup.jmxterm.jdk6.Jdk6JavaProcessManager;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.cyclopsgroup.jmxterm.pm.UnsupportedJavaProcessManager;
+
+import static org.apache.commons.lang3.JavaVersion.*;
 
 /**
  * Internal factory class to create JPM instance
@@ -21,7 +23,7 @@ public class JPMFactory
      */
     public JPMFactory()
     {
-        if ( !SystemUtils.isJavaVersionAtLeast( 150 ) )
+        if ( !SystemUtils.isJavaVersionAtLeast(JAVA_1_5) )
         {
             jpm =
                 new UnsupportedJavaProcessManager( "JDK version " + SystemUtils.JAVA_RUNTIME_VERSION

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/PredefinedCommandFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/PredefinedCommandFactory.java
@@ -6,8 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.collections.ExtendedProperties;
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.CommandFactory;
 import org.cyclopsgroup.jmxterm.utils.ExtendedPropertiesUtils;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/SessionImpl.java
@@ -7,7 +7,7 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.Connection;
 import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.Session;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/TypeMapCommandFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/TypeMapCommandFactory.java
@@ -3,7 +3,7 @@ package org.cyclopsgroup.jmxterm.cc;
 import java.util.Collections;
 import java.util.Map;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.CommandFactory;
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/BeanCommand.java
@@ -10,7 +10,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.Option;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/DomainCommand.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jmxterm.Command;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -12,7 +12,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 import org.apache.commons.collections.map.ListOrderedMap;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.MultiValue;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
@@ -18,9 +18,9 @@ import javax.management.MBeanParameterInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
-import org.apache.commons.lang.builder.CompareToBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.Option;
 import org.cyclopsgroup.jmxterm.Command;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/OpenCommand.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import javax.management.remote.JMXConnector;
 
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.Option;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/RunCommand.java
@@ -13,7 +13,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.MultiValue;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/SetCommand.java
@@ -12,7 +12,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.MultiValue;

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/WatchCommand.java
@@ -15,7 +15,7 @@ import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.MultiValue;

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/CommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/CommandOutput.java
@@ -1,6 +1,6 @@
 package org.cyclopsgroup.jmxterm.io;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 /**
  * General abstract class to output message and values

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandInput.java
@@ -6,7 +6,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Implementation of CommandInput with given File

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
@@ -5,7 +5,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Output with a file

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/InputStreamCommandInput.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Implementation of {@link CommandInput} with an input stream

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/JlineCommandInput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/JlineCommandInput.java
@@ -2,8 +2,8 @@ package org.cyclopsgroup.jmxterm.io;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 
 import jline.console.ConsoleReader;
 

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/PrintStreamCommandOutput.java
@@ -2,7 +2,7 @@ package org.cyclopsgroup.jmxterm.io;
 
 import java.io.PrintStream;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Implementation of CommandOutput where output is written in given PrintStream objects

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/ValueOutputFormat.java
@@ -6,8 +6,8 @@ import java.util.Map;
 
 import javax.management.openmbean.CompositeData;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 
 /**
  * A utility to print out object values in particular format.

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/VerboseCommandOutput.java
@@ -1,7 +1,7 @@
 package org.cyclopsgroup.jmxterm.io;
 
-import org.apache.commons.lang.Validate;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.Validate;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**
  * Command output implementation where detail message can be turned on and off dynamically

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/WriterCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/WriterCommandOutput.java
@@ -5,7 +5,7 @@ import java.io.PrintWriter;
 import java.io.Writer;
 
 import org.apache.commons.io.output.NullWriter;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * A command output that writes result and message to given writers

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcess.java
@@ -2,7 +2,7 @@ package org.cyclopsgroup.jmxterm.jdk5;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 
 /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcessManager.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcessManager.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cyclopsgroup.jmxterm.JavaProcess;

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcess.java
@@ -1,6 +1,6 @@
 package org.cyclopsgroup.jmxterm.jdk6;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 
 /**

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcessManager.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcessManager.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.utils.WeakCastUtils;

--- a/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactory.java
@@ -7,7 +7,7 @@ import java.net.URLClassLoader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 /**
  * Utility to get class loader that understands tools.jar and jconsole.jar

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/ExtendedPropertiesUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/ExtendedPropertiesUtils.java
@@ -6,7 +6,7 @@ import java.net.URL;
 import java.util.Enumeration;
 
 import org.apache.commons.collections.ExtendedProperties;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Utilities for loading overlapping properties files from classpath

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/ValueFormat.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/ValueFormat.java
@@ -1,7 +1,7 @@
 package org.cyclopsgroup.jmxterm.utils;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * This is an utility to parse string value from input. It's only to parse a value such as MBean attribute value or

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/WeakCastUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/WeakCastUtils.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 import javax.naming.OperationNotSupportedException;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 
 /**
  * Utility that cast object into given interface(s) even though class doesn't implement interface(s)

--- a/src/test/java/org/cyclopsgroup/jmxterm/SelfRecordingCommand.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/SelfRecordingCommand.java
@@ -2,7 +2,7 @@ package org.cyclopsgroup.jmxterm;
 
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
 import org.cyclopsgroup.jcli.annotation.MultiValue;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
@@ -8,7 +8,7 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.SelfRecordingCommand;
 import org.jmock.Expectations;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/DomainsCommandTest.java
@@ -6,7 +6,7 @@ import java.io.StringWriter;
 
 import javax.management.MBeanServerConnection;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -12,7 +12,7 @@ import javax.management.MBeanInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -11,7 +11,7 @@ import javax.management.MBeanParameterInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.Session;
 import org.jmock.Expectations;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
@@ -1,6 +1,6 @@
 package org.cyclopsgroup.jmxterm.cmd;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
@@ -1,6 +1,6 @@
 package org.cyclopsgroup.jmxterm.cmd;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
@@ -6,8 +6,8 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcessManagerTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/jdk5/Jdk5JavaProcessManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.junit.Test;

--- a/src/test/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcessManagerTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/jdk6/Jdk6JavaProcessManagerTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertFalse;
 
 import java.util.List;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.JavaProcess;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.junit.Test;

--- a/src/test/java/org/cyclopsgroup/jmxterm/jdk6/LocalVirtualMachineTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/jdk6/LocalVirtualMachineTest.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.cyclopsgroup.jmxterm.utils.WeakCastUtils;
 import org.junit.Test;

--- a/src/test/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactoryTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/pm/JConsoleClassLoaderFactoryTest.java
@@ -2,10 +2,11 @@ package org.cyclopsgroup.jmxterm.pm;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.apache.commons.lang.SystemUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.junit.Test;
 
+import static org.apache.commons.lang3.JavaVersion.*;
 /**
  * Test loading jconsole classes
  * 
@@ -30,7 +31,7 @@ public class JConsoleClassLoaderFactoryTest
         {
             clazz = cl.loadClass( "sun.jvmstat.monitor.MonitoredVm" );
         }
-        else if ( SystemUtils.IS_JAVA_1_6 || SystemUtils.IS_JAVA_1_7 )
+        else if ( SystemUtils.isJavaVersionAtLeast(JAVA_1_6) )
         {
             clazz = cl.loadClass( "sun.tools.jconsole.LocalVirtualMachine" );
         }


### PR DESCRIPTION
Since this project depends on jcli  and both depend on
Apache Commons Lang, jcli has also been updated.
The reason for updating is that the version of Apache Commons Lang (2.6) that was used, does not support JDK 1.8