### PR TITLE
Add an option in the Help to view detailed operations information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
-.*
 *.log
+.classpath
+.project
+.settings
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - openjdk6
+script:
+  - mvn clean
+  - mvn verify

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
@@ -19,6 +19,7 @@ import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.commons.lang.builder.CompareToBuilder;
 import org.cyclopsgroup.jcli.annotation.Cli;
@@ -56,6 +57,8 @@ public class InfoCommand
     private boolean showDescription;
 
     private String type = "aon";
+
+    private String operation;
 
     private void displayAttributes( MBeanInfo info )
     {
@@ -126,6 +129,38 @@ public class InfoCommand
         }
     }
 
+    private void displaySingleOperation(MBeanInfo info) {
+        Session session = getSession();
+        MBeanOperationInfo[] operationInfos = info.getOperations();
+        if (operationInfos.length == 0) {
+            session.output.printMessage("there's no operations");
+            return;
+        }
+        session.output.println(TEXT_OPERATIONS);
+        int index = 0;
+        boolean found = false;
+        for (MBeanOperationInfo op : operationInfos) {
+            String opName = op.getName();
+            if (StringUtils.equals(opName, operation)) {
+                found = true;
+                MBeanParameterInfo[] paramInfos = op.getSignature();
+                List<String> paramTypes = new ArrayList<String>(paramInfos.length);
+                StringBuilder paramsDesc = new StringBuilder("             parameters:" + SystemUtils.LINE_SEPARATOR);
+                for (MBeanParameterInfo paramInfo : paramInfos) {
+                    String parameter = paramInfo.getType() + " " + paramInfo.getName();
+                    paramsDesc.append(String.format("                 + %s : %s" + SystemUtils.LINE_SEPARATOR, parameter, paramInfo.getDescription()));
+                    paramTypes.add(parameter);
+                }
+                session.output.println(String.format("  %%%-3d - %s %s(%s)" + (showDescription ? ", %s" : ""), index++, op.getReturnType(), opName,
+                        StringUtils.join(paramTypes, ','),
+                        op.getDescription()));
+                session.output.println(paramsDesc.toString());
+            }
+        }
+        if (!found) {
+            session.output.printMessage(String.format("The operation '%s' is not found in the bean.", operation));
+        }
+    }
     /**
      * @inheritDoc
      */
@@ -144,22 +179,26 @@ public class InfoCommand
         MBeanInfo info = con.getMBeanInfo( name );
         session.output.printMessage( "mbean = " + beanName );
         session.output.printMessage( "class name = " + info.getClassName() );
-        for ( char t : type.toCharArray() )
-        {
-            switch ( t )
+        if (operation == null) {
+            for (char t : type.toCharArray())
             {
+                switch (t) {
                 case 'a':
-                    displayAttributes( info );
+                    displayAttributes(info);
                     break;
                 case 'o':
-                    displayOperations( info );
+                    displayOperations(info);
                     break;
                 case 'n':
-                    displayNotifications( info );
+                    displayNotifications(info);
                     break;
                 default:
-                    throw new IllegalArgumentException( "Unrecognizable character " + t + " in type option " + type );
+                    throw new IllegalArgumentException("Unrecognizable character " + t + " in type option " + type);
+                }
             }
+        } else {
+            session.output.printMessage("operation = " + operation);
+            displaySingleOperation(info);
         }
     }
 
@@ -201,5 +240,11 @@ public class InfoCommand
         Validate.isTrue( StringUtils.isNotEmpty( type ), "Type can't be NULL" );
         Validate.isTrue( Pattern.matches( "^a?o?n?$", type ), "Type must be a?|o?|n?" );
         this.type = type;
+    }
+
+    @Option(name = "o", longName = "op", description = "Show a single operation with more details (including parameters information)")
+    public void setOperation(String operation) {
+        Validate.isTrue(StringUtils.isNotEmpty(operation), "Operation can't be NULL");
+        this.operation = operation;
     }
 }

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/InfoCommand.java
@@ -147,11 +147,11 @@ public class InfoCommand
                 List<String> paramTypes = new ArrayList<String>(paramInfos.length);
                 StringBuilder paramsDesc = new StringBuilder("             parameters:" + SystemUtils.LINE_SEPARATOR);
                 for (MBeanParameterInfo paramInfo : paramInfos) {
-                    String parameter = paramInfo.getType() + " " + paramInfo.getName();
-                    paramsDesc.append(String.format("                 + %s : %s" + SystemUtils.LINE_SEPARATOR, parameter, paramInfo.getDescription()));
-                    paramTypes.add(parameter);
+                    String parameter = paramInfo.getName();
+                    paramsDesc.append(String.format("                 + %-20s : %s" + SystemUtils.LINE_SEPARATOR, parameter, paramInfo.getDescription()));
+                    paramTypes.add(paramInfo.getType() + " " + parameter);
                 }
-                session.output.println(String.format("  %%%-3d - %s %s(%s)" + (showDescription ? ", %s" : ""), index++, op.getReturnType(), opName,
+                session.output.println(String.format("  %%%-3d - %s %s(%s), %s", index++, op.getReturnType(), opName,
                         StringUtils.join(paramTypes, ','),
                         op.getDescription()));
                 session.output.println(paramsDesc.toString());

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -132,4 +132,144 @@ public class InfoCommandTest
         assertEquals( "# operations" + SystemUtils.LINE_SEPARATOR + "  %0   - int x(java.lang.String a)",
                       output.toString().trim() );
     }
+
+    /**
+     * Test execution and show available options
+     * @throws Exception
+     */
+    @Test
+    public void testExecuteWithShowingSpecificOperation() throws Exception {
+        command.setBean("a:type=x");
+        command.setOperation("x");
+        final MBeanServerConnection con = context.mock(MBeanServerConnection.class);
+        final MBeanInfo beanInfo = context.mock(MBeanInfo.class);
+        final MBeanOperationInfo opInfo = context.mock(MBeanOperationInfo.class);
+        final MBeanParameterInfo paramInfo = context.mock(MBeanParameterInfo.class);
+        Session session = new MockSession(output, con);
+        context.checking(new Expectations() {
+
+            {
+                atLeast(1).of(con).getMBeanInfo(new ObjectName("a:type=x"));
+                will(returnValue(beanInfo));
+                allowing(beanInfo).getClassName();
+                will(returnValue("bogus class"));
+                one(beanInfo).getOperations();
+                will(returnValue(new MBeanOperationInfo[] {opInfo}));
+                allowing(opInfo).getDescription();
+                will(returnValue("bingo"));
+                one(opInfo).getSignature();
+                will(returnValue(new MBeanParameterInfo[] {paramInfo}));
+                one(paramInfo).getType();
+                will(returnValue(String.class.getName()));
+                one(paramInfo).getName();
+                will(returnValue("a"));
+                one(paramInfo).getDescription();
+                will(returnValue("My param description"));
+                one(opInfo).getReturnType();
+                will(returnValue("int"));
+                atLeast(1).of(opInfo).getName();
+                will(returnValue("x"));
+            }
+        });
+        command.setSession(session);
+        command.execute();
+        context.assertIsSatisfied();
+        assertEquals("# operations" + SystemUtils.LINE_SEPARATOR + "  %0   - int x(java.lang.String a)" + SystemUtils.LINE_SEPARATOR + "             parameters:"
+                + SystemUtils.LINE_SEPARATOR + "                 + java.lang.String a : My param description", output.toString().trim());
+    }
+
+    /**
+     * Test execution and show available options
+     * @throws Exception
+     */
+    @Test
+    public void testExecuteWithShowingNonExistingOperation() throws Exception {
+        command.setBean("a:type=x");
+        command.setOperation("y");
+        final MBeanServerConnection con = context.mock(MBeanServerConnection.class);
+        final MBeanInfo beanInfo = context.mock(MBeanInfo.class);
+        final MBeanOperationInfo opInfo = context.mock(MBeanOperationInfo.class);
+        Session session = new MockSession(output, con);
+        context.checking(new Expectations() {
+
+            {
+                atLeast(1).of(con).getMBeanInfo(new ObjectName("a:type=x"));
+                will(returnValue(beanInfo));
+                allowing(beanInfo).getClassName();
+                will(returnValue("bogus class"));
+                one(beanInfo).getOperations();
+                will(returnValue(new MBeanOperationInfo[] {opInfo}));
+                atLeast(1).of(opInfo).getName();
+                will(returnValue("x"));
+            }
+        });
+        command.setSession(session);
+        command.execute();
+        context.assertIsSatisfied();
+        assertEquals("# operations", output.toString().trim());
+    }
+
+    /**
+     * Test execution and show available options
+     * @throws Exception
+     */
+    @Test
+    public void testExecuteWithShowingMultipleMatchingOperations() throws Exception {
+        command.setBean("a:type=x");
+        command.setOperation("x");
+        final MBeanServerConnection con = context.mock(MBeanServerConnection.class);
+        final MBeanInfo beanInfo = context.mock(MBeanInfo.class);
+        final MBeanOperationInfo opInfo1 = context.mock(MBeanOperationInfo.class);
+        final MBeanOperationInfo opInfo2 = context.mock(MBeanOperationInfo.class, "mockOpInfo2");
+        final MBeanParameterInfo paramInfo1 = context.mock(MBeanParameterInfo.class);
+        final MBeanParameterInfo paramInfo2 = context.mock(MBeanParameterInfo.class, "mockParamInfo2");
+        Session session = new MockSession(output, con);
+        context.checking(new Expectations() {
+
+            {
+                atLeast(1).of(con).getMBeanInfo(new ObjectName("a:type=x"));
+                will(returnValue(beanInfo));
+                allowing(beanInfo).getClassName();
+                will(returnValue("bogus class"));
+                one(beanInfo).getOperations();
+                will(returnValue(new MBeanOperationInfo[] {opInfo1, opInfo2}));
+                allowing(opInfo1).getDescription();
+                will(returnValue("bingo"));
+                one(opInfo1).getSignature();
+                will(returnValue(new MBeanParameterInfo[] {paramInfo1}));
+                one(paramInfo1).getType();
+                will(returnValue(String.class.getName()));
+                one(paramInfo1).getName();
+                will(returnValue("a"));
+                one(paramInfo1).getDescription();
+                will(returnValue("My param description"));
+                one(opInfo1).getReturnType();
+                will(returnValue("int"));
+                atLeast(1).of(opInfo1).getName();
+                will(returnValue("x"));
+
+                allowing(opInfo2).getDescription();
+                will(returnValue("pilou"));
+                one(opInfo2).getSignature();
+                will(returnValue(new MBeanParameterInfo[] {paramInfo2}));
+                one(paramInfo2).getType();
+                will(returnValue(Double.TYPE.getName()));
+                one(paramInfo2).getName();
+                will(returnValue("b"));
+                one(paramInfo2).getDescription();
+                will(returnValue("My param 2 description"));
+                one(opInfo2).getReturnType();
+                will(returnValue("void"));
+                atLeast(1).of(opInfo2).getName();
+                will(returnValue("x"));
+            }
+        });
+        command.setSession(session);
+        command.execute();
+        context.assertIsSatisfied();
+        assertEquals("# operations" + SystemUtils.LINE_SEPARATOR + "  %0   - int x(java.lang.String a)" + SystemUtils.LINE_SEPARATOR + "             parameters:"
+                + SystemUtils.LINE_SEPARATOR + "                 + java.lang.String a : My param description" + SystemUtils.LINE_SEPARATOR + SystemUtils.LINE_SEPARATOR
+                + "  %1   - void x(double b)" + SystemUtils.LINE_SEPARATOR + "             parameters:" + SystemUtils.LINE_SEPARATOR
+                + "                 + double b : My param 2 description", output.toString().trim());
+    }
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -162,7 +162,7 @@ public class InfoCommandTest
                 one(paramInfo).getType();
                 will(returnValue(String.class.getName()));
                 one(paramInfo).getName();
-                will(returnValue("a"));
+                will(returnValue("myfakeparameter"));
                 one(paramInfo).getDescription();
                 will(returnValue("My param description"));
                 one(opInfo).getReturnType();
@@ -174,8 +174,11 @@ public class InfoCommandTest
         command.setSession(session);
         command.execute();
         context.assertIsSatisfied();
-        assertEquals("# operations" + SystemUtils.LINE_SEPARATOR + "  %0   - int x(java.lang.String a)" + SystemUtils.LINE_SEPARATOR + "             parameters:"
-                + SystemUtils.LINE_SEPARATOR + "                 + java.lang.String a : My param description", output.toString().trim());
+        StringBuilder result = new StringBuilder("# operations").append(SystemUtils.LINE_SEPARATOR);
+        result.append("  %0   - int x(java.lang.String myfakeparameter), bingo").append(SystemUtils.LINE_SEPARATOR);
+        result.append("             parameters:").append(SystemUtils.LINE_SEPARATOR);
+        result.append("                 + myfakeparameter      : My param description");
+        assertEquals(result.toString(), output.toString().trim());
     }
 
     /**
@@ -267,9 +270,13 @@ public class InfoCommandTest
         command.setSession(session);
         command.execute();
         context.assertIsSatisfied();
-        assertEquals("# operations" + SystemUtils.LINE_SEPARATOR + "  %0   - int x(java.lang.String a)" + SystemUtils.LINE_SEPARATOR + "             parameters:"
-                + SystemUtils.LINE_SEPARATOR + "                 + java.lang.String a : My param description" + SystemUtils.LINE_SEPARATOR + SystemUtils.LINE_SEPARATOR
-                + "  %1   - void x(double b)" + SystemUtils.LINE_SEPARATOR + "             parameters:" + SystemUtils.LINE_SEPARATOR
-                + "                 + double b : My param 2 description", output.toString().trim());
+        StringBuilder result = new StringBuilder("# operations").append(SystemUtils.LINE_SEPARATOR);
+        result.append("  %0   - int x(java.lang.String a), bingo").append(SystemUtils.LINE_SEPARATOR);
+        result.append("             parameters:").append(SystemUtils.LINE_SEPARATOR);
+        result.append("                 + a                    : My param description").append(SystemUtils.LINE_SEPARATOR).append(SystemUtils.LINE_SEPARATOR);
+        result.append("  %1   - void x(double b), pilou").append(SystemUtils.LINE_SEPARATOR);
+        result.append("             parameters:").append(SystemUtils.LINE_SEPARATOR);
+        result.append("                 + b                    : My param 2 description");
+        assertEquals(result.toString(), output.toString().trim());
     }
 }


### PR DESCRIPTION
Sometimes, we would like to have more information on the parameters of an operation. This patch will provide you with that functionality.

before 
```
$>info -e 
#mbean = com.strator.iris.middleoffice:name=EWalletMBean,type=EWalletMBean
#class name = com.strator.iris.server.middleoffice.mbeans.EWalletMBean
#there is no attribute
# operations
  %0   - void authentificationTerminal(java.lang.Integer groupeId,java.lang.Integer numeroCaisse), Authentification eWallet d'un terminal pour un groupeid et un numéro de caisse
#there's no notifications
```

After
```
$>info -o authentificationTerminal
#mbean = com.strator.iris.middleoffice:name=EWalletMBean,type=EWalletMBean
#class name = com.strator.iris.server.middleoffice.mbeans.EWalletMBean
#operation = authentificationTerminal
# operations
  %0   - void authentificationTerminal(java.lang.Integer groupeId,java.lang.Integer numeroCaisse), Authentification eWallet d'un terminal pour un groupeid et un numéro de caisse
             parameters:
                 + groupeId             : Le groupeid
                 + numeroCaisse         : Le numero de la caisse


```

Note : 
> The configuration for a build in travis-ci.com is also included
