### PR TITLE
Added support for CSV output by allowing delimiter to be set and making line break configurable.

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -36,6 +36,10 @@ public class GetCommand
 
     private String domain;
 
+    private boolean singleLine = false;
+
+    private String delimiter = "";
+
     private boolean showDescription;
 
     private boolean showQuotationMarks;
@@ -91,7 +95,11 @@ public class GetCommand
                 {
                     format.printExpression( session.output, attributeName, result, i.getDescription() );
                 }
+                session.output.print( delimiter );
+                if ( !singleLine )
+                {
                 session.output.println( "" );
+            }
             }
             else
             {
@@ -210,6 +218,18 @@ public class GetCommand
     public final void setSimpleFormat( boolean simpleFormat )
     {
         this.simpleFormat = simpleFormat;
+    }
+
+    @Option( name = "l", longName = "delimiter", description = "Sets an optional delimiter to be printed after the value" )
+    public final void setDelimiter( String delimiter )
+    {
+        this.delimiter = delimiter;
+    }
+
+    @Option( name = "n", longName = "singleLine", description = "Prints result without a newline - default is false" )
+    public final void setSingleLine( boolean singleLine )
+    {
+        this.singleLine = singleLine;
     }
 
 }


### PR DESCRIPTION
Parameters added to the get command:

* `delimiter, -l` - supports setting a delimiter to be written behind the retrieved attribute (default is empty)
* `singleLine, -s` - supports to write results without appending a line break (default is false)

This was added to support a CSV output format.

An example input script to generate CSV information e.g. for a tomcat server is:

```
get -b Catalina:name=http-8080,type=ThreadPool -s -l , -n currentThreadCount
get -b Catalina:name=http-8080,type=ThreadPool -s -l , -n currentThreadsBusy
get -b java.lang:type=Threading -s ThreadCount
```