### PR TITLE
Added new command to echo fixed text and timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>jmxterm</artifactId>
     <name>JMXTerm</name>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.4-3.8.0.1.30.0</version>
     <description>Command line based interactive JMX client</description>
     <url>http://www.cyclopsgroup.org/projects/jmxterm</url>
     <inceptionYear>2008</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>jmxterm</artifactId>
     <name>JMXTerm</name>
     <packaging>jar</packaging>
-    <version>1.4-3.8.0.1.30.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <description>Command line based interactive JMX client</description>
     <url>http://www.cyclopsgroup.org/projects/jmxterm</url>
     <inceptionYear>2008</inceptionYear>

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/EchoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/EchoCommand.java
@@ -1,16 +1,14 @@
 package org.cyclopsgroup.jmxterm.cmd;
 
 import java.io.IOException;
-import java.util.Map;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import javax.management.JMException;
 
-import org.apache.commons.collections.ExtendedProperties;
 import org.apache.commons.lang.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
 import org.cyclopsgroup.jcli.annotation.Cli;
@@ -18,8 +16,6 @@ import org.cyclopsgroup.jcli.annotation.MultiValue;
 import org.cyclopsgroup.jcli.annotation.Option;
 import org.cyclopsgroup.jmxterm.Command;
 import org.cyclopsgroup.jmxterm.Session;
-import org.cyclopsgroup.jmxterm.io.ValueOutputFormat;
-import org.cyclopsgroup.jmxterm.utils.ExtendedPropertiesUtils;
 
 /**
  * Command to echo text
@@ -44,7 +40,6 @@ public class EchoCommand
     /**
      * @inheritDoc
      */
-    @SuppressWarnings( "unchecked" )
     @Override
     public void execute()
         throws IOException, JMException

--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/EchoCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/EchoCommand.java
@@ -1,0 +1,125 @@
+package org.cyclopsgroup.jmxterm.cmd;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import javax.management.JMException;
+
+import org.apache.commons.collections.ExtendedProperties;
+import org.apache.commons.lang.Validate;
+import org.cyclopsgroup.jcli.annotation.Argument;
+import org.cyclopsgroup.jcli.annotation.Cli;
+import org.cyclopsgroup.jcli.annotation.MultiValue;
+import org.cyclopsgroup.jcli.annotation.Option;
+import org.cyclopsgroup.jmxterm.Command;
+import org.cyclopsgroup.jmxterm.Session;
+import org.cyclopsgroup.jmxterm.io.ValueOutputFormat;
+import org.cyclopsgroup.jmxterm.utils.ExtendedPropertiesUtils;
+
+/**
+ * Command to echo text
+ *
+ * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
+ */
+@Cli( name = "echo", description = "Prints predefined text or timestamps" )
+public class EchoCommand
+    extends Command
+{
+
+    private List<String> texts = new ArrayList<String>();
+
+    private boolean echoTimestamp;
+
+    private String timestampFormat = "dd.MM.yyyy HH:mm:ss";
+
+    private boolean singleLine = false;
+
+    private String delimiter = "";
+
+    /**
+     * @inheritDoc
+     */
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public void execute()
+        throws IOException, JMException
+    {
+        Session session = getSession();
+
+        for ( int i = 0 ; i < texts.size() ; i++ )
+        {
+            session.output.print( texts.get(i) );
+
+            if ( i < texts.size() - 1 )
+            {
+                session.output.print( delimiter );
+            }
+        }
+
+        if ( echoTimestamp )
+        {
+            if ( !texts.isEmpty() )
+            {
+                session.output.print( delimiter );
+            }
+            DateFormat df = new SimpleDateFormat( timestampFormat );
+            session.output.print( df.format( new Date() ) );
+            if ( texts.isEmpty() )
+            {
+                session.output.print( delimiter );
+            }
+        }
+
+        if ( !singleLine )
+        {
+            session.output.println( "" );
+        }
+    }
+
+    /**
+     * @param echoTimestamp True to echo the current system timestamp
+     */
+    @Option( name = "t", longName = "timestamp", description = "Echo the current system timestamp" )
+    public final void setEchoTimestamp( boolean echoTimestamp )
+    {
+        this.echoTimestamp = echoTimestamp;
+    }
+
+    /**
+     * @param echoTimestamp True to echo the current system timestamp
+     */
+    @Option( name = "f", longName = "format", description = "The format to be used for the timestamp" )
+    public final void setTimestampFormat( String timestampFormat )
+    {
+        this.timestampFormat = timestampFormat;
+    }
+
+    @Option( name = "l", longName = "delimiter", description = "Sets an optional delimiter to be printed after the value" )
+    public final void setDelimiter( String delimiter )
+    {
+        this.delimiter = delimiter;
+    }
+
+    @Option( name = "n", longName = "singleLine", description = "Prints result without a newline - default is false" )
+    public final void setSingleLine( boolean singleLine )
+    {
+        this.singleLine = singleLine;
+    }
+
+    /**
+     * @param attributes List of attribute names
+     */
+    @MultiValue( listType = ArrayList.class, minValues = 0 )
+    @Argument( displayName = "texts", description = "Texts to print" )
+    public final void setTexts( List<String> texts )
+    {
+        Validate.notNull( texts, "Texts can't be NULL" );
+        this.texts = texts;
+    }
+
+}

--- a/src/main/resources/META-INF/cyclopsgroup/jmxterm.properties
+++ b/src/main/resources/META-INF/cyclopsgroup/jmxterm.properties
@@ -1,4 +1,4 @@
-jmxterm.commands.name=quit,open,close,domains,domain,beans,bean,info,get,set,run,option,jvms,about,watch,subscribe,unsubscribe
+jmxterm.commands.name=quit,open,close,domains,domain,beans,bean,info,get,set,run,option,jvms,about,watch,subscribe,unsubscribe,echo
 jmxterm.commands.quit.type=org.cyclopsgroup.jmxterm.cmd.QuitCommand
 jmxterm.commands.quit.alias=exit,bye
 jmxterm.commands.open.type=org.cyclopsgroup.jmxterm.cmd.OpenCommand
@@ -17,6 +17,7 @@ jmxterm.commands.about.type=org.cyclopsgroup.jmxterm.cmd.AboutCommand
 jmxterm.commands.watch.type=org.cyclopsgroup.jmxterm.cmd.WatchCommand
 jmxterm.commands.subscribe.type=org.cyclopsgroup.jmxterm.cmd.SubscribeCommand
 jmxterm.commands.unsubscribe.type=org.cyclopsgroup.jmxterm.cmd.UnsubscribeCommand
+jmxterm.commands.echo.type=org.cyclopsgroup.jmxterm.cmd.EchoCommand
 
 jmxterm.about.software.name=jmxterm
 jmxterm.about.software.description=Command line based interactive JMX client softare

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/EchoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/EchoCommandTest.java
@@ -1,0 +1,124 @@
+package org.cyclopsgroup.jmxterm.cmd;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import javax.management.JMException;
+import javax.management.MBeanServerConnection;
+
+import org.apache.commons.lang.SystemUtils;
+import org.cyclopsgroup.jmxterm.MockSession;
+import org.jmock.Mockery;
+import org.jmock.lib.legacy.ClassImposteriser;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class EchoCommandTest {
+	
+	private EchoCommand command;
+	
+	private Mockery context;
+
+    private StringWriter output;
+    
+    private void echoText( final List<String> texts, final boolean echoTimestamp, final String timestampFormat, final boolean singleLine, final String delimiter,
+    		final String expectedValue )
+    {	
+    	command.setTexts( texts );
+    	command.setEchoTimestamp( echoTimestamp );
+    	if ( timestampFormat != null ) 
+    	{
+    		command.setTimestampFormat(timestampFormat);
+    	}
+    	command.setSingleLine( singleLine );
+    	command.setDelimiter( delimiter );
+    	
+    	final MBeanServerConnection con = context.mock( MBeanServerConnection.class );
+    	
+    	try {
+			command.setSession( new MockSession( output, con ) );
+			command.execute();
+			context.assertIsSatisfied();
+			assertEquals( expectedValue, output.toString() );
+    	}
+        catch ( JMException e )
+        {
+            throw new RuntimeException( "Test failed for unexpected JMException", e );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( "Test failed for unexpected IOException", e );
+        }
+    }
+    
+    /**
+     * Set up class to test
+     */
+    @Before
+    public void setUp()
+    {
+        command = new EchoCommand();
+        context = new Mockery();
+        context.setImposteriser( ClassImposteriser.INSTANCE );
+        output = new StringWriter();
+    }
+    
+    /**
+     * Test normal execution
+     */
+    @Test
+    public void testExecuteNormally()
+    {
+        echoText( Arrays.asList("a", "b"), false, "", false, "", "ab" + SystemUtils.LINE_SEPARATOR );
+    }
+    
+    /**
+     * Test echo timestamp
+     */
+    @Test
+    public void testExecuteWithTimestamp()
+    {
+    	String format = "dd.MM.yyyy HH:mm:ss";
+    	DateFormat df = new SimpleDateFormat(format);
+        echoText( new ArrayList<String>(), true, null, false, "", df.format(new Date()) + SystemUtils.LINE_SEPARATOR );
+    }
+    
+    /**
+     * Test echo timestamp in custom format
+     */
+    @Test
+    public void testExecuteWithTimestampAndCustomFormat()
+    {
+    	String format = "dd.MM.yyyy";
+    	DateFormat df = new SimpleDateFormat(format);
+    	echoText( new ArrayList<String>(), true, format, false, "", df.format(new Date()) + SystemUtils.LINE_SEPARATOR );
+    }
+    
+    /**
+     * Test with delimiter set
+     */
+    @Test
+    public void testExecuteWithDelimiter()
+    {
+    	echoText( Arrays.asList("a", "b"), false, "", false, ",", "a,b" + SystemUtils.LINE_SEPARATOR );
+    }
+    
+    /**
+     * Test in singleLine
+     */
+    @Test
+    public void testExecuteWithSingleLineOutput()
+    {
+    	echoText( Arrays.asList("a", "b"), false, "", true, "", "ab" );
+    }
+
+}


### PR DESCRIPTION
The command name is echo and the purpose it to be able to inject timestamps or fixed texts into output files.

The command allows the following options:
- `echoTimestamp - t` - Writes the current system timestamp
- `timestampFormat - f`- Adjusts the format for the timestamp to be written. Default is `dd.MM.yyyy HH:mm:ss`
- `delimiter - l` - Prints a delimiter behind the timestamp and between the texts provided (default is empty) 
- `singleLine - n` - Configures whether the output is written without a newline character (default is false, adding a line break at the end)

An example configuration for this is that prints the current system timestamp followed by a comma and no line break:

```
echo -t -l , -n
```

Another example configuration that prints "a,b,c" followed by a line break:

```
echo a b c -l ,
```
