### PR TITLE
Added global option to allow to preserve the output file

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMain.java
@@ -87,7 +87,7 @@ public class CliMain
         else
         {
             File outputFile = new File( options.getOutput() );
-            output = new FileCommandOutput( outputFile );
+            output = new FileCommandOutput( outputFile, options.isAppendToOutput() );
         }
         try
         {

--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -8,7 +8,7 @@ import org.cyclopsgroup.jcli.annotation.Option;
 
 /**
  * Options for main class
- * 
+ *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 @Cli( name = "jmxterm", description = "Main executable of JMX terminal CLI tool", note = "Without any option, this command opens an interactive command line based console. With a given input file, commands in file will be executed and process ends after file is processed" )
@@ -36,6 +36,8 @@ public class CliMainOptions
     private String input = STDIN;
 
     private boolean nonInteractive;
+
+    private boolean appendToOutput = false;
 
     private String output = STDOUT;
 
@@ -101,6 +103,14 @@ public class CliMainOptions
     public final boolean isExitOnFailure()
     {
         return exitOnFailure;
+    }
+
+    /**
+     * @return True if terminal exits on any failure
+     */
+    public final boolean isAppendToOutput()
+    {
+        return appendToOutput;
     }
 
     /**
@@ -204,5 +214,14 @@ public class CliMainOptions
     public final void setVerboseLevel( String verboseLevel )
     {
         this.verboseLevel = verboseLevel;
+    }
+
+    /**
+     * @param appendToOutput True if outputfile is preserved
+     */
+    @Option( name = "a", longName = "appendtooutput", description = "With this flag, the outputfile is preserved and content is appended to it" )
+    public final void setAppendToOutput( boolean appendToOutput )
+    {
+        this.appendToOutput = appendToOutput;
     }
 }

--- a/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/io/FileCommandOutput.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang.Validate;
 
 /**
  * Output with a file
- * 
+ *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class FileCommandOutput
@@ -23,7 +23,7 @@ public class FileCommandOutput
      * @param file File where the result is written to
      * @throws IOException IO error
      */
-    public FileCommandOutput( File file )
+    public FileCommandOutput( File file, boolean appendToOutput )
         throws IOException
     {
         Validate.notNull( file, "File can't be NULL" );
@@ -35,7 +35,7 @@ public class FileCommandOutput
                 throw new IOException( "Couldn't make directory " + af.getParentFile() );
             }
         }
-        fileWriter = new PrintWriter( new FileWriter( af ) );
+        fileWriter = new PrintWriter( new FileWriter( af, appendToOutput ) );
         output = new WriterCommandOutput( fileWriter, new PrintWriter( System.err, true ) );
     }
 

--- a/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/io/FileCommandOutputTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 
 /**
  * Test case for {@link FileCommandOutput}
- * 
+ *
  * @author <a href="mailto:jiaqi.guo@gmail.com">Jiaqi Guo</a>
  */
 public class FileCommandOutputTest
@@ -32,7 +32,7 @@ public class FileCommandOutputTest
 
     /**
      * Delete test file
-     * 
+     *
      * @throws IOException If file operation fails
      */
     @After
@@ -44,18 +44,40 @@ public class FileCommandOutputTest
 
     /**
      * Writes out some output and verify result
-     * 
+     *
      * @throws IOException If file IO fails
      */
     @Test
     public void testWrite()
         throws IOException
     {
-        FileCommandOutput output = new FileCommandOutput( testFile );
+        FileCommandOutput output = new FileCommandOutput( testFile, false );
         output.println( "helloworld" );
         output.printMessage( "say hello" );
         output.close();
 
         assertEquals( "helloworld", FileUtils.readFileToString( testFile ).trim() );
+    }
+    
+    /**
+     * Writes out some output and verify result
+     *
+     * @throws IOException If file IO fails
+     */
+    @Test
+    public void testWriteMultipleTimes()
+        throws IOException
+    {
+        FileCommandOutput output = new FileCommandOutput( testFile, false );
+        output.println( "helloworld" );
+        output.printMessage( "say hello" );
+        output.close();
+        
+        FileCommandOutput output2 = new FileCommandOutput( testFile, true );
+        output2.println( "helloworld2" );
+        output2.printMessage( "say hello2" );
+        output2.close();
+
+        assertEquals( "helloworld" + SystemUtils.LINE_SEPARATOR + "helloworld2", FileUtils.readFileToString( testFile ).trim() );
     }
 }


### PR DESCRIPTION
Added a global option:
- `appendtooutput - a` - Configures that the output file is preserved and content is appended to it (default is false to preserve backwards compatibility)