### PR TITLE
Added support for one level of nested attribute loading for CompositeDataStructures

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -69,9 +69,13 @@ public class GetCommand
         {
             for ( String arg : attributes )
             {
+                String[] attributeNameElements = arg.split("\\.");
+
+                String firstPath = attributeNameElements[0];
+
                 for ( MBeanAttributeInfo ai : ais )
                 {
-                    if ( ai.getName().equals( arg ) )
+                    if ( ai.getName().equals( firstPath ) )
                     {
                         attributeNames.put( arg, ai );
                         break;
@@ -86,7 +90,21 @@ public class GetCommand
             MBeanAttributeInfo i = entry.getValue();
             if ( i.isReadable() )
             {
-                Object result = con.getAttribute( name, attributeName );
+                String[] attributeNameElements = attributeName.split("\\.");
+
+                String attributeNameToRequest = attributeName;
+                if ( attributeNameElements.length > 1 ) {
+                    attributeNameToRequest = attributeNameElements[0];
+                }
+
+                Object result = con.getAttribute( name, attributeNameToRequest );
+
+                if ( result instanceof javax.management.openmbean.CompositeDataSupport ) {
+                    if ( attributeNameElements.length > 1 ) {
+                        result = ((javax.management.openmbean.CompositeDataSupport)result).get(attributeNameElements[1]);
+                    }
+                }
+
                 if ( simpleFormat )
                 {
                     format.printValue( session.output, result );
@@ -99,7 +117,7 @@ public class GetCommand
                 if ( !singleLine )
                 {
                 session.output.println( "" );
-            }
+                }
             }
             else
             {


### PR DESCRIPTION
Added support for nested attributes (one level).

If the attribute name contains a dot "." the first part of the attribute name is used to retrieve the CompositeDataStructure element and the second part, after the "." is used as the key to retrieve the value for from the data structure.

Example commands for tomcat to retrieve the used memory values for Heap and NonHeap are:
```
get -b java.lang:type=Memory -s -l , -n HeapMemoryUsage.used
get -b java.lang:type=Memory -s -l , -n NonHeapMemoryUsage.used
```