### PR TITLE
Add comment char escape capability

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/CommandCenter.java
@@ -37,6 +37,7 @@ import org.cyclopsgroup.jmxterm.io.VerboseLevel;
 public class CommandCenter
 {
     private static final String COMMAND_DELIMITER = "&&";
+    static final String ESCAPE_CHAR_REGEX = "(?<!\\\\)#";
 
     /**
      * Argument tokenizer that parses arguments
@@ -124,11 +125,10 @@ public class CommandCenter
             return;
         }
         // Truncate command if there's # character
-        int commandEnds = command.indexOf( '#' );
-        if ( commandEnds != -1 )
-        {
-            command = command.substring( 0, commandEnds );
-        }
+	// Note: this allows people to set properties to values with # (e.g.: set AttributeA /a/\\#something)
+	command = command
+		.split(ESCAPE_CHAR_REGEX)[0] //take out all commented out sections
+		.replace("\\#", "#"); //fix escaped to non-escaped comment charaters
         // If command includes multiple segments, call them one by one using recursive call
         if ( command.indexOf( COMMAND_DELIMITER ) != -1 )
         {

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/CommandCenterTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/CommandCenterTest.java
@@ -16,6 +16,9 @@ import org.cyclopsgroup.jmxterm.io.WriterCommandOutput;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.cyclopsgroup.jmxterm.cc.CommandCenter.ESCAPE_CHAR_REGEX;
+
+
 /**
  * Test case of {@link CommandCenter}
  * 
@@ -123,5 +126,22 @@ public class CommandCenterTest
     public void testSingleSimpleArgument()
     {
         runCommandAndVerifyArguments( "test 1", Arrays.asList( "1" ) );
+    }
+
+    @Test
+    public void testRegexEscapesCorrectly() {
+        final String s1 = "".split(ESCAPE_CHAR_REGEX)[0];
+        final String s2 = "a b c".split(ESCAPE_CHAR_REGEX)[0];
+        final String s3 = "a #b c".split(ESCAPE_CHAR_REGEX)[0];
+        final String s4 = "a #b c #".split(ESCAPE_CHAR_REGEX)[0];
+        final String s5 = "a \\#b c #".split(ESCAPE_CHAR_REGEX)[0];
+        final String s6 = "a #b c \\# something".split(ESCAPE_CHAR_REGEX)[0];
+
+        assertEquals("", s1);
+        assertEquals("a b c", s2);
+        assertEquals("a ", s3);
+        assertEquals("a ", s4);
+        assertEquals("a \\#b c ", s5);
+        assertEquals("a ", s6);
     }
 }


### PR DESCRIPTION
This PR allows people to set values in string attributes that contain the # character. The current code in master truncates immediately.

We faced this issue where we found that the following does not work:

set myAttribute /a/b/#/c/d/f

we want to be able to do for example

set myAttribute /a/b/\\#/c/d/f

The `#` here is original to the value, and NOT a comment. 