### PR TITLE
Using version 2.0.0 due to incompatibilities in history format

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,0 @@
-Read more in http://wiki.cyclopsgroup.org/jmxterm

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# JMXTerm
+
+An open source command line based interactive JMX client written in Java. It allows user to access a Java MBean server
+in command line console without graphical environment. In another word, it's a command line based jconsole.
+At runtime, JMXTerm implementation relies on JDK jconsole library while it doesn't require graphical environment 
+(such as X in Linux).
+
+JMXTerm can also be used to integrate with non-Java programming language such as PERL or SHELL and allow these languages
+to access Java MBean server programmatically. However as this page will point out later, there's no point of using
+JMXTerm to access MBean server programmatically in Java, as Java already provides good API.
+
+Read more at http://wiki.cyclopsgroup.org/jmxterm
+
+## Building
+
+Use Maven to build the code, test it and create a runnable JAR or installable Debian package
+
+    mvn package
+
+## Running
+
+An uber JAR containing every dependency is automatically created and can be run
+directly:
+
+    java -jar target/jmxterm-2.0.0-uber.jar
+
+## Installation
+
+Installable packages will be created for Debian based operating systems, other
+systems require a manual installation.
+
+### Debian / Ubuntu
+
+    sudo dpkg -i target/jmxterm_2.0.0_all.deb
+
+### Other Linux operating systems
+
+    sudo mkdir /usr/share/jmxterm
+    sudo cp target/jmxterm-2.0.0-uber.jar /usr/share/jmxterm/jmxterm-uber.jar
+    sudo cp src/main/script/jmxterm.sh /usr/bin/jmxterm
+    sudo chmod +x /usr/bin/jmxterm
+
+## Release Notes
+
+### Version 2.0.0
+
+We did a major dependency update in version 2.0.0, especially an upgrade to JLine 3. With version 2.0.0 you need to
+remove your previous history file using (Unix)
+
+    rm ~/.jmxterm_history
+    
+or (Windows)
+
+    del %HOMEPATH%\.jmxterm_history
+

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>jmxterm</artifactId>
     <name>JMXTerm</name>
     <packaging>jar</packaging>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>2.0.0</version>
     <description>Command line based interactive JMX client</description>
     <url>http://www.cyclopsgroup.org/projects/jmxterm</url>
     <inceptionYear>2008</inceptionYear>


### PR DESCRIPTION
Hi!

Thanks for merging the changes!

I would strongly recommend to set the version to 2.0.0, because the previous history format cannot be read by the new JLine version and users will get a message, that they need to remove this file.

Perhaps we should add a hint to http://wiki.cyclopsgroup.org/jmxterm on how to remove the old history file.

Best regards

Daniel