### PR TITLE
Fix for BUG 1731946  - Jmxterm does not start with Java 9 (NullPointerException)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
@jiaqi when the `jmxterm` is executed in jre11 it crashes straightway due to a null pointer exception immediately after is launched.  The issue is reported here [1731946](https://bugs.launchpad.net/jmxterm/+bug/1731946)

Upgrading to `commons-lang3` 3.8.1 fixes the crash, this is a know issue. 

```
java.lang.NullPointerException
	at org.codehaus.classworlds.Launcher.getEnhancedMainMethod(Launcher.java:195)
	at org.codehaus.classworlds.Launcher.launchEnhanced(Launcher.java:294)
	at org.codehaus.classworlds.Launcher.launch(Launcher.java:255)
	at org.codehaus.classworlds.Launcher.mainWithExitCode(Launcher.java:430)
	at org.codehaus.classworlds.Launcher.main(Launcher.java:375)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.codehaus.classworlds.uberjar.boot.Bootstrapper.bootstrap(Bootstrapper.java:209)
	at org.codehaus.classworlds.uberjar.boot.Bootstrapper.main(Bootstrapper.java:116)
```