### PR TITLE
Exclude /usr/bin in rpm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
             </mapping>
             <mapping>
               <directory>/usr/bin</directory>
+              <directoryIncluded>false</directoryIncluded>
               <filemode>755</filemode>
               <sources>
                 <source>


### PR DESCRIPTION
Resolve part of #54,  exclude /usr/bin in rpm
On CentOS 7 the installation of rpm failed with conflict error on /usr/bin
```
[root@abc001 ~]# rpm -ivh jmxterm-1.0.0-1.noarch.rpm
Preparing...                          ################################# [100%]
	file /usr/bin from install of jmxterm-1.0.0-1.noarch conflicts with file from package filesystem-3.2-21.el7.x86_64
```
Before fix:
```
[root@abc001 ~]# rpm -ql jmxterm
/usr/bin
/usr/bin/jmxterm
/usr/share/doc/jmxterm
/usr/share/jmxterm
/usr/share/jmxterm/jmxterm-uber.jar
```

After fix:
```
[root@abc001 ~]# rpm -ql jmxterm
/usr/bin/jmxterm
/usr/share/doc/jmxterm
/usr/share/jmxterm
/usr/share/jmxterm/jmxterm-uber.jar
```