### PR TITLE
[ISSUE 51] Add support for (m)TLS

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/boot/CliMainOptions.java
@@ -49,6 +49,8 @@ public class CliMainOptions {
 
   private String verboseLevel;
 
+  private boolean isSecureRmiRegistry;
+
   /**
    * @return #setInput(String)
    */
@@ -117,6 +119,14 @@ public class CliMainOptions {
    */
   public final boolean isNonInteractive() {
     return nonInteractive;
+  }
+
+  /**
+   * @return True if the server's RMI registry is protected with SSL/TLS
+   *         (com.sun.management.jmxremote.registry.ssl=true)
+   */
+  public final boolean isSecureRmiRegistry() {
+    return isSecureRmiRegistry;
   }
 
   /**
@@ -211,5 +221,15 @@ public class CliMainOptions {
       description = "With this flag, the outputfile is preserved and content is appended to it")
   public final void setAppendToOutput(boolean appendToOutput) {
     this.appendToOutput = appendToOutput;
+  }
+
+  /**
+   * @param isSecureRmiRegistry Whether the server's RMI registry is protected with SSL/TLS
+   *                            (com.sun.management.jmxremote.registry.ssl=true)
+   */
+  @Option(name = "s", longName = "sslrmiregistry",
+          description = "Whether the server's RMI registry is protected with SSL/TLS")
+  public final void setSecureRmiRegistry(final boolean isSecureRmiRegistry) {
+    this.isSecureRmiRegistry = isSecureRmiRegistry;
   }
 }


### PR DESCRIPTION
Sample invocations:

TLS:
```
% java -Djavax.net.ssl.trustStore=<trust_store> -Djavax.net.ssl.trustStorePassword=<trust_store_password> -Djavax.net.debug=ssl:all -jar jmxterm-1.0.1-SNAPSHOT-uber.jar -l <host>:<jmx_port> -u <jmx_user> -p <jmx_password>
```
mTLS:
```
% java -Djavax.net.ssl.trustStore=<trust_store> -Djavax.net.ssl.trustStorePassword=<trust_store_password> -Djavax.net.ssl.keyStore=<key_store> -Djavax.net.ssl.keyStorePassword=<key_store_password> -Djavax.net.debug=ssl:all -jar jmxterm-1.0.1-SNAPSHOT-uber.jar -l <host>:<jmx_port> -u <jmx_user> -p <jmx_password>
```