### PR TITLE
New format for to display mbean and attribute value in single line

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -44,6 +44,8 @@ public class GetCommand extends Command {
 
   private boolean simpleFormat;
 
+  private boolean completeLine;
+
   private void displayAttributes() throws IOException, JMException {
     Session session = getSession();
     String beanName = BeanCommand.getBeanName(bean, domain, session);
@@ -94,6 +96,9 @@ public class GetCommand extends Command {
 
         if (simpleFormat) {
           format.printValue(session.output, result);
+        } else if (completeLine) {
+          String updateResult = "mbean = " + beanName + " # " + attributeName + " = " + result;
+          format.printValue(session.output, updateResult);
         } else {
           format.printExpression(session.output, attributeName, result, i.getDescription());
         }
@@ -191,6 +196,16 @@ public class GetCommand extends Command {
       description = "Print simple expression of value without full expression")
   public final void setSimpleFormat(boolean simpleFormat) {
     this.simpleFormat = simpleFormat;
+  }
+
+  /**
+   * @param completeLine True if value is printed out in a complete </bean # value> single line
+   * expression
+   */
+  @Option(name = "f", longName = "completeLine", description = "Print expression with bean and "
+      + "value in single line with '#' delimiter")
+  public final void setZFormat(boolean completeLine) {
+    this.completeLine = completeLine;
   }
 
   @Option(name = "l", longName = "delimiter",

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -105,7 +105,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteNormally() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "" );
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "");
   }
 
   /**
@@ -166,5 +166,4 @@ public class GetCommandTest {
   public void testExecuteForSingleLineOutput() {
     getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
   }
-
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -39,11 +39,12 @@ public class GetCommandTest {
 
   private void getAttributeAndVerify(final String domain, String bean, final String attribute,
       final String expectedBean, final Object expectedValue, final boolean singleLine,
-      final String delimiter) {
+      final String delimiter, final boolean simpleFormat, final boolean completeLine) {
     command.setDomain(domain);
     command.setBean(bean);
     command.setAttributes(Arrays.asList(attribute));
-    command.setSimpleFormat(true);
+    command.setSimpleFormat(simpleFormat);
+    command.setZFormat(completeLine);
     command.setSingleLine(singleLine);
     command.setDelimiter(delimiter);
 
@@ -105,7 +106,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteNormally() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "");
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "", true, false );
   }
 
   /**
@@ -113,12 +114,12 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithNonStringType() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", new Integer(10), false, "");
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", new Integer(10), false, "", true, false);
   }
 
   @Test
   public void testExecuteWithSlashInDomainName() {
-    getAttributeAndVerify("a/b", "type=c", "a", "a/b:type=c", "bingo", false, "");
+    getAttributeAndVerify("a/b", "type=c", "a", "a/b:type=c", "bingo", false, "", true, false);
   }
 
   /**
@@ -140,7 +141,7 @@ public class GetCommandTest {
       }
     });
     Object expectedValue = new CompositeDataSupport(compositeType, entries);
-    getAttributeAndVerify("a", "type=x", "a_b-c.d", "a:type=x", expectedValue, false, "");
+    getAttributeAndVerify("a", "type=x", "a_b-c.d", "a:type=x", expectedValue, false, "", true, false);
   }
 
   /**
@@ -148,7 +149,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithUnusualDomainAndBeanName() {
-    getAttributeAndVerify("a-a", "a.b-c_d=x-y.z", "a", "a-a:a.b-c_d=x-y.z", "bingo", false, "");
+    getAttributeAndVerify("a-a", "a.b-c_d=x-y.z", "a", "a-a:a.b-c_d=x-y.z", "bingo", false, "", true,   false);
   }
 
   /**
@@ -156,7 +157,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithDelimiters() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, ",");
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, ",", true, false);
   }
 
   /**
@@ -164,6 +165,15 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteForSingleLineOutput() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "", true,false);
+  }
+
+  /**
+   * Verify that complete line output is working
+   */
+  @Test
+  public void testExecuteForCompleteLineOutput() {
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false,
+        "", false,true);
   }
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -39,12 +39,11 @@ public class GetCommandTest {
 
   private void getAttributeAndVerify(final String domain, String bean, final String attribute,
       final String expectedBean, final Object expectedValue, final boolean singleLine,
-      final String delimiter, final boolean simpleFormat, final boolean completeLine) {
+      final String delimiter) {
     command.setDomain(domain);
     command.setBean(bean);
     command.setAttributes(Arrays.asList(attribute));
-    command.setSimpleFormat(simpleFormat);
-    command.setZFormat(completeLine);
+    command.setSimpleFormat(true);
     command.setSingleLine(singleLine);
     command.setDelimiter(delimiter);
 
@@ -106,7 +105,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteNormally() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "", true, false );
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "" );
   }
 
   /**
@@ -114,12 +113,12 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithNonStringType() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", new Integer(10), false, "", true, false);
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", new Integer(10), false, "");
   }
 
   @Test
   public void testExecuteWithSlashInDomainName() {
-    getAttributeAndVerify("a/b", "type=c", "a", "a/b:type=c", "bingo", false, "", true, false);
+    getAttributeAndVerify("a/b", "type=c", "a", "a/b:type=c", "bingo", false, "");
   }
 
   /**
@@ -141,7 +140,7 @@ public class GetCommandTest {
       }
     });
     Object expectedValue = new CompositeDataSupport(compositeType, entries);
-    getAttributeAndVerify("a", "type=x", "a_b-c.d", "a:type=x", expectedValue, false, "", true, false);
+    getAttributeAndVerify("a", "type=x", "a_b-c.d", "a:type=x", expectedValue, false, "");
   }
 
   /**
@@ -149,7 +148,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithUnusualDomainAndBeanName() {
-    getAttributeAndVerify("a-a", "a.b-c_d=x-y.z", "a", "a-a:a.b-c_d=x-y.z", "bingo", false, "", true,   false);
+    getAttributeAndVerify("a-a", "a.b-c_d=x-y.z", "a", "a-a:a.b-c_d=x-y.z", "bingo", false, "");
   }
 
   /**
@@ -157,7 +156,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithDelimiters() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, ",", true, false);
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "");
   }
 
   /**
@@ -165,7 +164,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteForSingleLineOutput() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "", true,false);
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
   }
 
   /**
@@ -174,6 +173,6 @@ public class GetCommandTest {
   @Test
   public void testExecuteForCompleteLineOutput() {
     getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false,
-        "", false,true);
+        "");
   }
 }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -105,7 +105,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteNormally() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "" );
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "" );
   }
 
   /**
@@ -156,7 +156,7 @@ public class GetCommandTest {
    */
   @Test
   public void testExecuteWithDelimiters() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, "");
+    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false, ",");
   }
 
   /**
@@ -167,12 +167,4 @@ public class GetCommandTest {
     getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", true, "");
   }
 
-  /**
-   * Verify that complete line output is working
-   */
-  @Test
-  public void testExecuteForCompleteLineOutput() {
-    getAttributeAndVerify("a", "type=x", "a", "a:type=x", "bingo", false,
-        "");
-  }
 }


### PR DESCRIPTION
I am looking for a new formatter which can display both the mbean + attribute value in a single line, so that it will be easy for to integrate the jmxterm in a background process to auto pull the jvm metrics on a periodic time.