### PR TITLE
Handle 30x redirects and switch to downloads.apache.org

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 COPY . /tmp/jmxterm
 
-RUN curl -sSL -o /tmp/apache-maven-3.6.3-bin.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+RUN curl -sSL -o /tmp/apache-maven-3.6.3-bin.tar.gz https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
     tar zxvf /tmp/apache-maven-3.6.3-bin.tar.gz -C /tmp && \
     cd /tmp/jmxterm && \
     /tmp/apache-maven-3.6.3/bin/mvn install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 COPY . /tmp/jmxterm
 
-RUN curl -o /tmp/apache-maven-3.6.3-bin.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+RUN curl -sSL -o /tmp/apache-maven-3.6.3-bin.tar.gz https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
     tar zxvf /tmp/apache-maven-3.6.3-bin.tar.gz -C /tmp && \
     cd /tmp/jmxterm && \
     /tmp/apache-maven-3.6.3/bin/mvn install && \


### PR DESCRIPTION
```
$ curl -v https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
*   Trying 40.79.78.1...
* TCP_NODELAY set
* Connected to www-us.apache.org (40.79.78.1) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use http/1.1
* Server certificate:
*  subject: OU=Domain Control Validated; OU=PositiveSSL Wildcard; CN=*.apache.org
*  start date: Jul  1 00:00:00 2019 GMT
*  expire date: Jun 30 23:59:59 2021 GMT
*  subjectAltName: host "www-us.apache.org" matched cert's "*.apache.org"
*  issuer: C=GB; ST=Greater Manchester; L=Salford; O=Sectigo Limited; CN=Sectigo RSA Domain Validation Secure Server CA
*  SSL certificate verify ok.
> GET /dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz HTTP/1.1
> Host: www-us.apache.org
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 302 Found
< Date: Thu, 12 Mar 2020 23:13:04 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Location: https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
< Cache-Control: max-age=3600
< Expires: Fri, 13 Mar 2020 00:13:04 GMT
< Content-Length: 271
< Content-Type: text/html; charset=iso-8859-1
< 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz">here</a>.</p>
</body></html>
* Connection #0 to host www-us.apache.org left intact
```