### PR TITLE
Bump commons-configuration2 and -text versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-configuration2</artifactId>
-      <version>2.2</version>
+      <version>2.7</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.2</version>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
I bumped `commons-configuration2` to 2.7 from 2.2 to address https://nvd.nist.gov/vuln/detail/CVE-2020-1953.

This also required bumping `commons-text` to 1.9 from 1.2 in order to remediate a `NoClassDefFoundError` that came up after bumping `commons-configuration2` alone.