### PR TITLE
continue on exceptions when showing all bean attributes

### DIFF
--- a/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cmd/GetCommand.java
@@ -9,6 +9,7 @@ import javax.management.JMException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.RuntimeMBeanException;
 import org.apache.commons.collections4.map.ListOrderedMap;
 import org.apache.commons.lang3.Validate;
 import org.cyclopsgroup.jcli.annotation.Argument;
@@ -86,7 +87,14 @@ public class GetCommand extends Command {
           attributeNameToRequest = attributeNameElements[0];
         }
 
-        Object result = con.getAttribute(name, attributeNameToRequest);
+        Object result = null;
+
+        try {
+          result = con.getAttribute(name, attributeNameToRequest);
+        } catch (RuntimeMBeanException e) {
+          session.output.printMessage(
+              "Could not get attribute " + attributeNameToRequest + ": " + e.getMessage());
+        }
 
         if (result instanceof javax.management.openmbean.CompositeDataSupport) {
           if (attributeNameElements.length > 1) {


### PR DESCRIPTION
This is a potential fix for an issue described here https://developer.jboss.org/thread/250550

Output example:

```
$>info
#mbean = java.lang:name=G1 Eden Space,type=MemoryPool
#class name = sun.management.MemoryPoolImpl
# attributes
  %0   - CollectionUsage (javax.management.openmbean.CompositeData, r)
  %1   - CollectionUsageThreshold (long, rw)
  %2   - CollectionUsageThresholdCount (long, r)
  %3   - CollectionUsageThresholdExceeded (boolean, r)
  %4   - CollectionUsageThresholdSupported (boolean, r)
  %5   - MemoryManagerNames ([Ljava.lang.String;, r)
  %6   - Name (java.lang.String, r)
  %7   - ObjectName (javax.management.ObjectName, r)
  %8   - PeakUsage (javax.management.openmbean.CompositeData, r)
  %9   - Type (java.lang.String, r)
  %10  - Usage (javax.management.openmbean.CompositeData, r)
  %11  - UsageThreshold (long, rw)
  %12  - UsageThresholdCount (long, r)
  %13  - UsageThresholdExceeded (boolean, r)
  %14  - UsageThresholdSupported (boolean, r)
  %15  - Valid (boolean, r)
# operations
  %0   - void resetPeakUsage()
#there's no notifications

$>get *
#mbean = java.lang:name=G1 Eden Space,type=MemoryPool:
Name = G1 Eden Space;

Type = HEAP;

Valid = true;

Usage = {
  committed = 547356672;
  init = 550502400;
  max = -1;
  used = 32505856;
 };

PeakUsage = {
  committed = 550502400;
  init = 550502400;
  max = -1;
  used = 524288000;
 };

MemoryManagerNames = [ G1 Old Generation, G1 Young Generation ];

#Could not get attribute UsageThreshold: java.lang.UnsupportedOperationException: Usage threshold is not supported
UsageThreshold = null;

#Could not get attribute UsageThresholdExceeded: java.lang.UnsupportedOperationException: Usage threshold is not supported
UsageThresholdExceeded = null;

#Could not get attribute UsageThresholdCount: java.lang.UnsupportedOperationException: Usage threshold is not supported
UsageThresholdCount = null;

UsageThresholdSupported = false;

CollectionUsageThreshold = 0;

CollectionUsageThresholdExceeded = false;

CollectionUsageThresholdCount = 0;

CollectionUsage = {
  committed = 547356672;
  init = 550502400;
  max = -1;
  used = 0;
 };

CollectionUsageThresholdSupported = true;

ObjectName = java.lang:type=MemoryPool,name=G1 Eden Space;
```

With this fix, it still shows all attributes, and does not stop on the first exception.