### PR TITLE
Address https://nvd.nist.gov/vuln/detail/CVE-2022-42889 by upgrading …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.9</version>
+      <version>1.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.cyclopsgroup</groupId>


### PR DESCRIPTION
…org.apache.commons:commons-text to version 1.10.0 (from 1.9)