### PR TITLE
Fix for mvn site command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/maven-v4_0_0.xsd">
+                      https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.cyclopsgroup</groupId>
@@ -135,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.5.0</version>
         <configuration>
           <show>protected</show>
           <failOnError>true</failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -177,16 +177,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>site</phase>
             <configuration>
-              <tasks>
+              <target>
                 <echo message="Copy file..."/>
                 <copy todir="${basedir}/target/site">
                   <fileset dir="${basedir}/target" includes="jmxterm-*-uber.jar"/>
                 </copy>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<project name="JMXTERM: Command line based interative JMX client">
+<project name="JMXTERM: Command line based interactive JMX client">
     <bannerLeft>
         <name>jmxterm - Command line JMX</name>
         <src>images/logo.png</src>
@@ -7,26 +7,23 @@
     </bannerLeft>
     <bannerRight>
         <src>
-            http://cyclops-group.sourceforge.net/wiki/images/cyclopsgroup-logo.png
+            https://cyclops-group.sourceforge.net/wiki/images/cyclopsgroup-logo.png
         </src>
     </bannerRight>
     <body>
         <head>
-            <script type="text/javascript"
-                src="http://www.google-analytics.com/urchin.js">
-            </script>
-            <script type="text/javascript">
-                <![CDATA[
+            <![CDATA[
+                <script type="text/javascript" src="https://www.google-analytics.com/urchin.js"></script>
+                <script type="text/javascript">
                     _uacct = "UA-76203-1";
                     urchinTracker();
-                ]]>
-            </script>
+                </script>
+            ]]>
         </head>
         <links>
             <item name="wiki site" href="https://github.com/jiaqi/jmxterm/wiki" />
-            <item name="cyclopsgroup.org" href="http://www.cyclopsgroup.org/" />
-            <item name="github"
-                href="https://github.com/jiaqi/jmxterm" />
+            <item name="cyclopsgroup.org" href="https://www.cyclopsgroup.org/" />
+            <item name="github" href="https://github.com/jiaqi/jmxterm" />
         </links>
         <menu ref="reports" />
     </body>


### PR DESCRIPTION
Hello,

Small PR to fix the `mvn site` command which is failing with Maven 3.9.3.

The first error I had was:

```
SiteToolException: Error parsing site descriptor: TEXT must be immediately followed by END_TAG and not START_TAG (position: START_TAG seen ..."\n                src="http://www.google-analytics.com/urchin.js">... @16:65)
```

I fixed it by escaping both `script` tags in the `head` tag, see: https://stackoverflow.com/questions/67315542/mvn-site-plugin-error-text-must-be-immediately-followed-by-end-tag-and-not-start.

The second error was related to a breaking change in the configuration of `maven-antrun-plugin`, `tasks` should be replaced by `target`, see: https://maven.apache.org/plugins/maven-antrun-plugin/.

```
You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site.
```

Now the command succeeds but there is still an issue with `maven-javadoc-plugin`, fixed by upgrading the plugin to version 3.5.0.

```
[WARNING] An issue has occurred with maven-javadoc-plugin:3.4.0:aggregate-no-fork report, skipping LinkageError org.apache.maven.plugins.javadoc.AggregatorJavadocNoForkReport.generate(Lorg/codehaus/doxia/sink/Sink;Ljava/util/Locale;)V, please report an issue to Maven dev team.
```

Let me know if I've missed anything.
nyg