### PR TITLE
Fix tests for Java 17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
     <url>https://travis-ci.org/jiaqi/jmxterm</url>
   </ciManagement>
   <properties>
-    <jmock.version>2.8.3</jmock.version>
+    <byte-buddy.version>1.14.11</byte-buddy.version>
+    <jmock.version>2.12.0</jmock.version>
     <slf4j.version>1.7.25</slf4j.version>
   </properties>
   <dependencies>
@@ -97,6 +98,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>${byte-buddy.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock</artifactId>
       <version>${jmock.version}</version>
@@ -104,7 +111,7 @@
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-legacy</artifactId>
+      <artifactId>jmock-imposters</artifactId>
       <version>${jmock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
@@ -11,7 +11,7 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.SelfRecordingCommand;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class HelpCommandTest {
     command = new HelpCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,7 +99,7 @@ public class GetCommandTest {
   public void setUp() {
     command = new GetCommand();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     output = new StringWriter();
   }
 

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -13,7 +13,7 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.Session;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ public class InfoCommandTest {
     command = new InfoCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
@@ -12,7 +12,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class RunCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     command = new RunCommand();
     output = new StringWriter();
   }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
@@ -17,8 +17,8 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.api.Invocation;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.lib.action.CustomAction;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class SetCommandTest {
     command = new SetCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   private void setValueAndVerify(String expr, final String type, final Object expected) {

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
@@ -13,7 +13,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class SubscribeCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     command = new SubscribeCommand();
     output = new StringWriter();
   }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
@@ -12,7 +12,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class UnsubscribeCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     subscribeCommand = new SubscribeCommand();
     unsubscribeCommand = new UnsubscribeCommand();
     output = new StringWriter();


### PR DESCRIPTION
Hello,

I have not able to run mvn clean install with Java 21. The issue was due to unit tests failing. I fixed it by:

1. updating jmock, Java 11 support was added in 2.10.0,
2. removing jmock-legacy which used cglib by jmock-imposters which uses byte-buddy,
3. specify latest version of byte-buddy for Java 11+ support.

So now jmxterm can be built using Java 21, but running it still fails when listing JVM (due to other issues).

Best,
nyg