### PR TITLE
Avoid usage of jdk.jconsole module in Java 9+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,8 @@
     <url>https://travis-ci.org/jiaqi/jmxterm</url>
   </ciManagement>
   <properties>
-    <jmock.version>2.8.3</jmock.version>
+    <byte-buddy.version>1.14.11</byte-buddy.version>
+    <jmock.version>2.12.0</jmock.version>
     <slf4j.version>1.7.25</slf4j.version>
   </properties>
   <dependencies>
@@ -97,6 +98,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>${byte-buddy.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock</artifactId>
       <version>${jmock.version}</version>
@@ -104,7 +111,7 @@
     </dependency>
     <dependency>
       <groupId>org.jmock</groupId>
-      <artifactId>jmock-legacy</artifactId>
+      <artifactId>jmock-imposters</artifactId>
       <version>${jmock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/cc/JPMFactory.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.cyclopsgroup.jmxterm.JavaProcessManager;
 import org.cyclopsgroup.jmxterm.jdk5.Jdk5JavaProcessManager;
 import org.cyclopsgroup.jmxterm.jdk6.Jdk6JavaProcessManager;
+import org.cyclopsgroup.jmxterm.jdk9.Jdk9JavaProcessManager;
 import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
 import org.cyclopsgroup.jmxterm.pm.UnsupportedJavaProcessManager;
 
@@ -27,16 +28,18 @@ public class JPMFactory {
     JavaProcessManager j;
     try {
       ClassLoader cl = JConsoleClassLoaderFactory.getClassLoader();
-      if (SystemUtils.IS_JAVA_1_5) {
-        j = new Jdk5JavaProcessManager(cl);
-      } else {
+      if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+        j = new Jdk9JavaProcessManager(cl);
+      } else if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_1_6)) {
         j = new Jdk6JavaProcessManager(cl);
+      } else {
+        j = new Jdk5JavaProcessManager(cl);
       }
     } catch (ClassNotFoundException e) {
       j =
           new UnsupportedJavaProcessManager(
               e.getMessage()
-                  + ", operation on this JDK("
+                  + ", operation on this JDK ("
                   + SystemUtils.JAVA_RUNTIME_VERSION
                   + ") isn't fully supported",
               e);

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk5/package-info.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk5/package-info.java
@@ -1,2 +1,2 @@
-/** Classes to implement {@link org.cyclopsgroup.jmxterm.JavaProcessManager} in JDK5 specifi way */
+/** Classes to implement {@link org.cyclopsgroup.jmxterm.JavaProcessManager} in JDK5 specific way */
 package org.cyclopsgroup.jmxterm.jdk5;

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcess.java
@@ -1,0 +1,63 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+import java.io.IOException;
+import org.apache.commons.lang3.Validate;
+import org.cyclopsgroup.jmxterm.JavaProcess;
+import org.cyclopsgroup.jmxterm.utils.WeakCastUtils;
+
+/**
+ * JDK9 specific implementation of {@link JavaProcess}
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public class Jdk9JavaProcess implements JavaProcess {
+
+  private final StaticVirtualMachine staticVirtualMachine;
+  private final VirtualMachineDescriptor vmd;
+  private final String address;
+
+  /**
+   * @param staticVm Static VirtualMachine proxy
+   * @param vmd Local VM
+   * @param address Connector address, if any
+   */
+  Jdk9JavaProcess(StaticVirtualMachine staticVm, VirtualMachineDescriptor vmd, String address) {
+    Validate.notNull(vmd, "StaticVirtualMachine can't be NULL");
+    Validate.notNull(vmd, "VirtualMachineDescriptor can't be NULL");
+    this.staticVirtualMachine = staticVm;
+    this.vmd = vmd;
+    this.address = address;
+  }
+
+  @Override
+  public String getDisplayName() {
+    return vmd.displayName();
+  }
+
+  @Override
+  public int getProcessId() {
+    return Integer.parseInt(vmd.id());
+  }
+
+  @Override
+  public boolean isManageable() {
+    return address != null;
+  }
+
+  @Override
+  public void startManagementAgent() throws IOException {
+    Object vm = staticVirtualMachine.attach(vmd.id());
+    try {
+      Class<?> originalVirtualMachine = Class.forName(VirtualMachine.ORIGINAL_CLASS_NAME);
+      VirtualMachine vmProxy = WeakCastUtils.cast(originalVirtualMachine, VirtualMachine.class);
+      vmProxy.startLocalManagementAgent();
+    } catch (ClassNotFoundException | SecurityException | NoSuchMethodException e) {
+      throw new RuntimeException("Can't cast " + vm + " to VirtualMachineDescriptor", e);
+    }
+  }
+
+  @Override
+  public String toUrl() {
+    return address;
+  }
+}

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManager.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManager.java
@@ -1,0 +1,63 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import org.apache.commons.lang3.Validate;
+import org.cyclopsgroup.jmxterm.JavaProcess;
+import org.cyclopsgroup.jmxterm.JavaProcessManager;
+import org.cyclopsgroup.jmxterm.utils.WeakCastUtils;
+
+/**
+ * JDK9 specific java process manager
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public class Jdk9JavaProcessManager extends JavaProcessManager {
+  private final StaticVirtualMachine staticVirtualMachine;
+  private final Class<?> originalVirtualMachine;
+
+  public Jdk9JavaProcessManager(ClassLoader classLoader)
+      throws SecurityException, NoSuchMethodException, ClassNotFoundException {
+    Validate.notNull(classLoader, "ClassLoader can't be NULL");
+    originalVirtualMachine = classLoader.loadClass(VirtualMachine.ORIGINAL_CLASS_NAME);
+    staticVirtualMachine =
+        WeakCastUtils.staticCast(originalVirtualMachine, StaticVirtualMachine.class);
+  }
+
+  @Override
+  public JavaProcess get(int pid) {
+    return list().stream().filter(process -> process.getProcessId() == pid).findAny().orElse(null);
+  }
+
+  @Override
+  public List<JavaProcess> list() {
+    List<Object> vmDescriptors = staticVirtualMachine.list();
+    List<JavaProcess> result = new ArrayList<>(vmDescriptors.size());
+
+    for (Object vmd : vmDescriptors) {
+      VirtualMachineDescriptor vmdProxy = null;
+      VirtualMachine vmProxy = null;
+
+      try {
+        vmdProxy = WeakCastUtils.cast(vmd, VirtualMachineDescriptor.class);
+        Object vm = staticVirtualMachine.attach(vmdProxy.id());
+        vmProxy = WeakCastUtils.cast(originalVirtualMachine, vm, VirtualMachine.class);
+
+        Properties agentProps = vmProxy.getAgentProperties();
+        String address = (String) agentProps.get(VirtualMachine.LOCAL_CONNECTOR_ADDRESS_PROP);
+        result.add(new Jdk9JavaProcess(staticVirtualMachine, vmdProxy, address));
+      } catch (SecurityException | NoSuchMethodException e) {
+        throw new RuntimeException("Error casting object", e);
+      } catch (Exception e) {
+        // could not attach or some other exception
+        result.add(new Jdk9JavaProcess(staticVirtualMachine, vmdProxy, null));
+      } finally {
+        if (vmProxy != null) {
+          vmProxy.detach();
+        }
+      }
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/StaticVirtualMachine.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/StaticVirtualMachine.java
@@ -1,0 +1,16 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+import java.util.List;
+
+/**
+ * Static interface of com.sun.tools.attach.VirtualMachine
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public interface StaticVirtualMachine {
+  /** @return List of all virtual machines running on local */
+  List<Object> list();
+
+  /** Attaches to a Java virtual machine. */
+  Object attach(String id);
+}

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/VirtualMachine.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/VirtualMachine.java
@@ -1,0 +1,25 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+import java.util.Properties;
+
+/**
+ * Reflect class com.sun.tools.attach.VirtualMachine
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public interface VirtualMachine {
+  /** Name of original class this interface reflects */
+  String ORIGINAL_CLASS_NAME = "com.sun.tools.attach.VirtualMachine";
+
+  /** Property for the local connector address */
+  String LOCAL_CONNECTOR_ADDRESS_PROP = "com.sun.management.jmxremote.localConnectorAddress";
+
+  /** Detach from the virtual machine. */
+  void detach();
+
+  /** @return The current agent properties in the target virtual machine. */
+  Properties getAgentProperties();
+
+  /** Starts the local JMX management agent in the target virtual machine. */
+  void startLocalManagementAgent();
+}

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/VirtualMachineDescriptor.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/VirtualMachineDescriptor.java
@@ -1,0 +1,17 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+/**
+ * Reflect class com.sun.tools.attach.VirtualMachineDescriptor
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public interface VirtualMachineDescriptor {
+  /** Name of original class this interface reflects */
+  String ORIGINAL_CLASS_NAME = "com.sun.tools.attach.VirtualMachineDescriptor";
+
+  /** @return The display name component of this descriptor */
+  String displayName();
+
+  /** @return The identifier component of this descriptor */
+  String id();
+}

--- a/src/main/java/org/cyclopsgroup/jmxterm/jdk9/package-info.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/jdk9/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Classes to implement {@link org.cyclopsgroup.jmxterm.JavaProcessManager} in JDK9 specific way
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+package org.cyclopsgroup.jmxterm.jdk9;

--- a/src/main/java/org/cyclopsgroup/jmxterm/utils/WeakCastUtils.java
+++ b/src/main/java/org/cyclopsgroup/jmxterm/utils/WeakCastUtils.java
@@ -19,6 +19,7 @@ public final class WeakCastUtils {
   /**
    * Cast object into multiple interfaces
    *
+   * @param original The interface of the from instance
    * @param from Object to cast
    * @param interfaces Interfaces to cast to
    * @param classLoader ClassLoader to load methods for invocation
@@ -26,7 +27,11 @@ public final class WeakCastUtils {
    * @throws SecurityException Allows exception related to security.
    * @throws NoSuchMethodException Allows exception due to wrong method.
    */
-  public static Object cast(final Object from, final Class<?>[] interfaces, ClassLoader classLoader)
+  public static Object cast(
+      final Class<?> original,
+      final Object from,
+      final Class<?>[] interfaces,
+      ClassLoader classLoader)
       throws SecurityException, NoSuchMethodException {
     Validate.notNull(from, "Invocation target can't be NULL");
     Validate.notNull(interfaces, "Interfaces can't be NULL");
@@ -35,8 +40,7 @@ public final class WeakCastUtils {
     for (Class<?> interfase : interfaces) {
       Validate.isTrue(interfase.isInterface(), interfase + " is not an interface");
       for (Method fromMethod : interfase.getMethods()) {
-        Method toMethod =
-            from.getClass().getMethod(fromMethod.getName(), fromMethod.getParameterTypes());
+        Method toMethod = original.getMethod(fromMethod.getName(), fromMethod.getParameterTypes());
         methodMap.put(fromMethod, toMethod);
       }
     }
@@ -74,7 +78,23 @@ public final class WeakCastUtils {
    */
   public static <T> T cast(Object from, Class<T> interfase)
       throws SecurityException, NoSuchMethodException {
-    return cast(from, interfase, interfase.getClassLoader());
+    return cast(from.getClass(), from, interfase, interfase.getClassLoader());
+  }
+
+  /**
+   * Cast object to one given interface using ClassLoader of interface
+   *
+   * @param original The interface of the from instance
+   * @param <T> Type of interface
+   * @param from Object to cast
+   * @param interfase Interface to cast to
+   * @return Result that implements interface
+   * @throws SecurityException Allows exception related to security.
+   * @throws NoSuchMethodException Allows exception due to wrong method.
+   */
+  public static <T> T cast(Class<?> original, Object from, Class<T> interfase)
+      throws SecurityException, NoSuchMethodException {
+    return cast(original, from, interfase, interfase.getClassLoader());
   }
 
   /**
@@ -89,10 +109,11 @@ public final class WeakCastUtils {
    * @throws NoSuchMethodException Allows exception due to wrong method.
    */
   @SuppressWarnings("unchecked")
-  public static <T> T cast(Object from, Class<T> interfase, ClassLoader classLoader)
+  public static <T> T cast(
+      Class<?> original, Object from, Class<T> interfase, ClassLoader classLoader)
       throws SecurityException, NoSuchMethodException {
     Validate.notNull(interfase, "Interface can't be NULL");
-    return (T) cast(from, new Class<?>[] {interfase}, classLoader);
+    return (T) cast(original, from, new Class<?>[] {interfase}, classLoader);
   }
 
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cc/HelpCommandTest.java
@@ -11,7 +11,7 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.SelfRecordingCommand;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ public class HelpCommandTest {
     command = new HelpCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/GetCommandTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -99,7 +99,7 @@ public class GetCommandTest {
   public void setUp() {
     command = new GetCommand();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     output = new StringWriter();
   }
 

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/InfoCommandTest.java
@@ -13,7 +13,7 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.cyclopsgroup.jmxterm.Session;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +35,7 @@ public class InfoCommandTest {
     command = new InfoCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   /**

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/RunCommandTest.java
@@ -12,7 +12,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class RunCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     command = new RunCommand();
     output = new StringWriter();
   }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SetCommandTest.java
@@ -17,8 +17,8 @@ import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.api.Invocation;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.lib.action.CustomAction;
-import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class SetCommandTest {
     command = new SetCommand();
     output = new StringWriter();
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
   }
 
   private void setValueAndVerify(String expr, final String type, final Object expected) {

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/SubscribeCommandTest.java
@@ -13,7 +13,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class SubscribeCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     command = new SubscribeCommand();
     output = new StringWriter();
   }

--- a/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/cmd/UnsubscribeCommandTest.java
@@ -12,7 +12,7 @@ import javax.management.ObjectName;
 import org.cyclopsgroup.jmxterm.MockSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +34,7 @@ public class UnsubscribeCommandTest {
   @Before
   public void setUp() {
     context = new Mockery();
-    context.setImposteriser(ClassImposteriser.INSTANCE);
+    context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     subscribeCommand = new SubscribeCommand();
     unsubscribeCommand = new UnsubscribeCommand();
     output = new StringWriter();

--- a/src/test/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManagerTest.java
+++ b/src/test/java/org/cyclopsgroup/jmxterm/jdk9/Jdk9JavaProcessManagerTest.java
@@ -1,0 +1,29 @@
+package org.cyclopsgroup.jmxterm.jdk9;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.List;
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
+import org.cyclopsgroup.jmxterm.JavaProcess;
+import org.cyclopsgroup.jmxterm.pm.JConsoleClassLoaderFactory;
+import org.junit.Test;
+
+/**
+ * Test case of {@link Jdk9JavaProcessManager}
+ *
+ * @author <a href="https://github.com/nyg">nyg</a>
+ */
+public class Jdk9JavaProcessManagerTest {
+
+  @Test
+  public void testConstruction() throws Exception {
+    if (!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+      return;
+    }
+    Jdk9JavaProcessManager jpm =
+        new Jdk9JavaProcessManager(JConsoleClassLoaderFactory.getClassLoader());
+    List<JavaProcess> ps = jpm.list();
+    assertFalse(ps.isEmpty());
+  }
+}


### PR DESCRIPTION
Hello,

Since Java 9, there is a warning (illegal reflective access operation) when using the jdk.jconsole module which contains classes like `LocalVirtualMachine` that are used to list local VMs and attach to them. On later Java version (17?), accessing these classes makes jmxterm crash.

I implemented a `Jdk9JavaProcessManager` which relies only on the public Attach API (which is actually what `LocalVirtualMachine` appears to use under the hood, see: https://github.com/openjdk/jdk/blob/jdk8-b120/jdk/src/share/classes/sun/tools/jconsole/LocalVirtualMachine.java#L123). So my code is voluntarily based on what goes on in LocalVirtualMachine (especially when listing VMs).

I had to adapt `WeakCastUtils` to build the `methodMap` using not the `from` instance (which in Jdk9 case is an instance of `VirtualMachineImpl` which is not part of the public API) but using the "original" interface, i.e. `VirtualMachine`. When this distinction is not needed, I just use `from.getClass()`.

The source and target version remain Java 8.

Also, as the mininum Java version is 8, I'm not sure it's useful to keep `Jdk5JavaProcessManager`.

If `WeakCastUtils` doesn't serve any other purpose than supporting multiple Java version, probably it could be replaced with Java 9 multi-release JARs: https://nipafx.dev/multi-release-jars-multiple-java-versions/.

Note 1: this PR includes my other PR (#112).

Note 2: as I answered in #48, making jmxterm work with Java 17+ can be done by allowing access to the jdk.jconsole module (with `--add-exports jdk.jconsole/...`) but this is not supported by Java 8 and cannot be used with the Java 9 `--release` option.

Best,
nyg

Fixes #48
Fixes #87

EDIT: I tested in the following way: compiled and ran (running `jvms` and `open`) jmxterm with both JDK8 and JDK21, but always leaving the maven.compiler.source and target to 1.8.