### PR TITLE
Fix broken user manual link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,4 +73,4 @@ Get value of MBean attribute(s)
 ```
 
 Jmxterm can do a lot more. Check out the
-[user manual](doc/user_manual.md) for more complicated usage.
+[user manual](doc/manual.md) for more complicated usage.


### PR DESCRIPTION
The "user manual" link under "Check out the user manual for more complicated usage" points to `doc/user_manual.md`, which doesn't exist and 404s. The actual file is `doc/manual.md`.